### PR TITLE
Add name attribute to metadata

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -1,3 +1,4 @@
+name             "redis"
 maintainer       "dkd Internet Service GmbH"
 maintainer_email "christian.trabold@dkd.de"
 license          "All rights reserved"


### PR DESCRIPTION
Chef gives an error without this:
```
ERROR: Could not read /Users/heaven/workspace/chef/cookbooks/redis into a Chef object: Cookbook loaded at path(s) [/Users/heaven/workspace/chef/cookbooks/redis] has invalid metadata: The `name' attribute is required in cookbook metadata
ERROR: /Users/heaven/.rvm/gems/ruby-2.3.1@chef/gems/chef-12.17.44/lib/chef/cookbook/cookbook_version_loader.rb:195:in `raise_metadata_error!'
```